### PR TITLE
Added a CredentialManager to save our secrets

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,11 @@
   ],
   "activationEvents": [
     "onCommand:twitchhighlighter.highlight",
-    "onCommand:twitchhighlighter.startChat"
+    "onCommand:twitchhighlighter.startChat",
+    "onCommand:twitchhighlighter.setTwitchClientId",
+    "onCommand:twitchhighlighter.removeTwitchClientId",
+    "onCommand:twitchhighlighter.setTwitchPassword",
+    "onCommand:twitchhighlighter.removeTwitchPassword"
   ],
   "main": "./out/extension",
   "contributes": {
@@ -35,6 +39,22 @@
       {
         "command": "twitchhighlighter.stopChat",
         "title": "Twitch Highlighter: Stop Listening to Chat"
+      },
+      {
+        "command": "twitchhighlighter.setTwitchClientId",
+        "title": "Twitch Highlighter: Set Client Id"
+      },
+      {
+        "command": "twitchhighlighter.removeTwitchClientId",
+        "title": "Twitch Highlighter: Remove Client Id"
+      },
+      {
+        "command": "twitchhighlighter.setTwitchPassword",
+        "title": "Twitch Highlighter: Set Password"        
+      },
+      {
+        "command": "twitchhighlighter.removeTwitchPassword",
+        "title": "Twitch Highlighter: Remove Password"
       }
     ]
   },
@@ -56,11 +76,6 @@
         "type": "number",
         "default": 6667,
         "description": "The IRC server port."
-      },
-      "twitchhighlighter.password": {
-        "type": "string",
-        "default": "",
-        "description": "IRC server password. Leave empty if not needed. For Twitch generate a token here: http://www.twitchapps.com/tmi"
       },
       "twitchhighlighter.nickname": {
         "type": "string",
@@ -88,6 +103,7 @@
   },
   "devDependencies": {
     "@types/mocha": "^2.2.42",
+    "@types/keytar": "^4.0.1",
     "@types/node": "^8.10.39",
     "tslint": "^5.8.0",
     "typescript": "^2.6.1"

--- a/src/credentialManager.ts
+++ b/src/credentialManager.ts
@@ -1,0 +1,81 @@
+import * as keytartype from 'keytar';
+import { env } from 'vscode';
+
+declare const __webpack_require__: typeof require;
+declare const __non_webpack_require__: typeof require;
+
+function getNodeModule<T>(moduleName: string): T | undefined {
+  const r = typeof __webpack_require__ === 'function' ? __non_webpack_require__ : require;
+  try {
+    return r(`${env.appRoot}/node_modules.asar/${moduleName}`);
+  }
+  catch (err) {
+    // Not in ASAR.
+  }
+  try {
+    return r(`${env.appRoot}/node_modules/${moduleName}`);
+  }
+  catch (err) {
+    // Not available
+  }
+  return undefined;
+}
+
+export interface TwitchCredentials {
+  clientId: string;
+  password: string;
+}
+
+export class CredentialManager {
+  private static service: string = "vscode-twitch-highlighter";
+  private static clientIdIdentifier: string = "twitchClientId";
+  private static passwordIdentifier: string = "twitchToken";
+  private static keytar: typeof keytartype | undefined = getNodeModule<typeof keytartype>('keytar');
+
+  public static async setClientId(value: string): Promise<void> {
+    if (CredentialManager.keytar && value !== null) {
+      await CredentialManager.keytar.setPassword(CredentialManager.service, CredentialManager.clientIdIdentifier, value);
+    }    
+  }
+  public static async deleteTwitchClientId(): Promise<boolean> {
+    if(CredentialManager.keytar) {
+      return await CredentialManager.keytar.deletePassword(CredentialManager.service, CredentialManager.clientIdIdentifier);
+    }
+    return false;
+  }
+  public static async setPassword(value: string): Promise<void> {
+    if (CredentialManager.keytar && value !== null) {
+      await CredentialManager.keytar.setPassword(CredentialManager.service, CredentialManager.passwordIdentifier, value);
+    }
+  }
+  public static async deletePassword(): Promise<boolean> {
+    if (CredentialManager.keytar) {
+      return await CredentialManager.keytar.deletePassword(CredentialManager.service, CredentialManager.passwordIdentifier);
+    }
+    return false;
+  }
+  public static getTwitchCredentials(): Promise<TwitchCredentials | null> {
+    return new Promise<TwitchCredentials | null>(async resolve => {
+      const clientId = await CredentialManager.getPassword(CredentialManager.clientIdIdentifier);
+      const password = await CredentialManager.getPassword(CredentialManager.passwordIdentifier);
+      if (clientId === null || password === null) {
+        resolve(null);
+        return;
+      }
+      const twitchCredential: TwitchCredentials = {
+        clientId,
+        password
+      };
+      resolve(twitchCredential);
+    });
+  }
+
+  private static async getPassword(account: string): Promise<string | null> {
+    if (CredentialManager.keytar) {
+      return await CredentialManager.keytar.getPassword(CredentialManager.service, account);
+    }
+    return null;
+  }
+}
+
+export default CredentialManager;

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,9 +7,12 @@ import {
   InitializedParams,
   TextDocumentSyncKind
 } from 'vscode-languageserver/lib/main';
+import { TwitchCredentials } from './credentialManager';
 
 const tmi = require('twitch-js');
-const ttvChatClient = new tmi.client(getTwitchChatOptions());
+
+let twitchCredentials: TwitchCredentials;
+let ttvChatClient: any;
 
 let connection: IConnection = createConnection(
   new IPCMessageReader(process),
@@ -20,6 +23,8 @@ let connection: IConnection = createConnection(
 connection.onInitialize(
   (params): InitializeResult => {
     // workspaceRoot = params.rootPath;
+    twitchCredentials = params.initializationOptions.TwitchCredentials;
+    ttvChatClient = new tmi.client(getTwitchChatOptions());
 
     return {
       capabilities: {
@@ -174,10 +179,10 @@ function getTwitchChatOptions() {
       reconnect: true
     },
     identity: {
-      password: '<your password>'
+      password: twitchCredentials.password
     },
     options: {
-      clientId: '<your clientId>',
+      clientId: twitchCredentials.clientId,
       debug: false
     }
   };


### PR DESCRIPTION
# Added files

## credentialManager.ts
  I added a credentialManager.ts to set and retrieve the ClientId and Token from the users keychain (credential store). This uses a node module (keytar) but loads it using VSCode's version of Node.

# Changed files

## package.json
  I added 4 commands:
    - twitchhighlighter.setTwitchClientId
    - twitchhighlighter.removeTwitchClientId
    - twitchhighlighter.setTwitchPassword
    - twitchhighlighter.removeTwitchPassword

  I removed the `twitchhighlighter.password` extension setting because the password will no longer be saved there

## extension.ts
  I setup the registration of the commands and created the handlers
  I changed the `startChatHandler` to first retrieve the `TwitchCredentials` from the `CredentialManager` before starting the client

## server.ts
  I declared the `ttvChatClient` within the `connection.onInitialize` function so we can initialize the `twitchCredentials` prior to retrieving the twitch chat options
  I changed the `getTwitchChatOptions` function to get the password and clientId from `twitchCredentials`