### PR TITLE
Use VSCode user settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,5 +10,6 @@
   },
   // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
   "typescript.tsc.autoDetect": "off",
-  "typescript.tsdk": "node_modules\\typescript\\lib"
+  "typescript.tsdk": "node_modules\\typescript\\lib",
+  "prettier.singleQuote": true
 }

--- a/package.json
+++ b/package.json
@@ -128,6 +128,11 @@
           "default": [],
           "description": "The channel name. For Twitch, use #${your channel/user name}."
         },
+        "twitchhighlighter.nickname": {
+          "type": "string",
+          "default": "",
+          "description": "The username the bot should use when joining a Twitch channel."
+        },
         "twitchhighlighter.highlightColor": {
           "type": "string",
           "default": "green",

--- a/package.json
+++ b/package.json
@@ -127,6 +127,16 @@
           "type": "array",
           "default": [],
           "description": "The channel name. For Twitch, use #${your channel/user name}."
+        },
+        "twitchhighlighter.highlightColor": {
+          "type": "string",
+          "default": "green",
+          "description": "Background color of the decoration. Use rgba() and define transparent background colors to play well with other decorations. Alternatively a color from the color registry can be [referenced](#ThemeColor)"
+        },
+        "twitchhighlighter.highlightBorder": {
+          "type": "string",
+          "default": "2px solid white",
+          "description": "CSS styling property that will be applied to text enclosed by a decoration."
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -137,6 +137,21 @@
           "type": "string",
           "default": "2px solid white",
           "description": "CSS styling property that will be applied to text enclosed by a decoration."
+        },
+        "twitchhighlighter.announceBot": {
+          "type": "boolean",
+          "default": true,
+          "description": "Whether or not the bot should announce its joining or leaving the chat room"
+        },
+        "twitchhighlighter.joinMessage": {
+          "type": "string",
+          "default": "Twitch Highlighter in the house!",
+          "description": "The message the bot will say when joining a chat room"
+        },
+        "twitchhighlighter.leaveMessage": {
+          "type": "string",
+          "default": "Twitch Highlighter has left the building!",
+          "description": "The message the bot will say when leaving a chat room"
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
       },
       {
         "command": "twitchhighlighter.setTwitchPassword",
-        "title": "Twitch Highlighter: Set Password"        
+        "title": "Twitch Highlighter: Set Password"
       },
       {
         "command": "twitchhighlighter.removeTwitchPassword",
@@ -70,7 +70,7 @@
     ],
     "menus": {
       "commandPalette": [
-        {          
+        {
           "when": "false",
           "command": "twitchhighlighter.toggleChat"
         },
@@ -116,7 +116,7 @@
         {
           "id": "twitchHighlighterTreeView",
           "name": "Highlights"
-        }        
+        }
       ]
     },
     "configuration": {
@@ -126,7 +126,7 @@
         "twitchhighlighter.channels": {
           "type": "array",
           "default": [],
-          "description": "The channel name. For Twitch, use #${your channel/user name}."
+          "description": "The channel name(s) to connect to on Twitch. Example: ['clarkio'], Another Example: ['clarkio', 'parithon']"
         },
         "twitchhighlighter.nickname": {
           "type": "string",
@@ -136,7 +136,7 @@
         "twitchhighlighter.highlightColor": {
           "type": "string",
           "default": "green",
-          "description": "Background color of the decoration. Use rgba() and define transparent background colors to play well with other decorations. Alternatively a color from the color registry can be [referenced](#ThemeColor)"
+          "markdownDescription": "Background color of the decoration. Use rgba() and define transparent background colors to play well with other decorations. Example: green"
         },
         "twitchhighlighter.highlightBorder": {
           "type": "string",

--- a/package.json
+++ b/package.json
@@ -115,8 +115,7 @@
       "twitchhighlighter-explorer": [
         {
           "id": "twitchHighlighterTreeView",
-          "name": "Highlights",
-          "when": "config.twitchhighlighter.shouldConnect"
+          "name": "Highlights"
         }        
       ]
     },
@@ -124,35 +123,10 @@
       "type": "object",
       "title": "Twitch Highlighter Configuration",
       "properties": {
-        "twitchhighlighter.shouldConnect": {
-          "type": "boolean",
-          "default": true,
-          "description": "Whether to connect to Twitch Chat."
-        },
-        "twitchhighlighter.server": {
-          "type": "string",
-          "default": "irc.chat.twitch.tv",
-          "description": "The Twitch server to connect to."
-        },
-        "twitchhighlighter.port": {
-          "type": "number",
-          "default": 6667,
-          "description": "The IRC server port."
-        },
-        "twitchhighlighter.nickname": {
-          "type": "string",
-          "default": "clarkio",
-          "description": "IRC nickname. For Twitch, use your username."
-        },
-        "twitchhighlighter.channel": {
-          "type": "string",
-          "default": "#clarkio",
+        "twitchhighlighter.channels": {
+          "type": "array",
+          "default": [],
           "description": "The channel name. For Twitch, use #${your channel/user name}."
-        },
-        "twitchhighlighter.command": {
-          "type": "string",
-          "default": ":highlight",
-          "description": "The command for your viewers to use."
         }
       }
     }

--- a/src/credentialManager.ts
+++ b/src/credentialManager.ts
@@ -22,8 +22,8 @@ function getNodeModule<T>(moduleName: string): T | undefined {
 }
 
 export interface TwitchCredentials {
-  clientId: string;
-  password: string;
+  clientId: string | null;
+  password: string | null;
 }
 
 export class CredentialManager {
@@ -54,14 +54,10 @@ export class CredentialManager {
     }
     return false;
   }
-  public static getTwitchCredentials(): Promise<TwitchCredentials | null> {
-    return new Promise<TwitchCredentials | null>(async resolve => {
+  public static getTwitchCredentials(): Promise<TwitchCredentials> {
+    return new Promise<TwitchCredentials>(async resolve => {
       const clientId = await CredentialManager.getPassword(CredentialManager.clientIdIdentifier);
       const password = await CredentialManager.getPassword(CredentialManager.passwordIdentifier);
-      if (clientId === null || password === null) {
-        resolve(null);
-        return;
-      }
       const twitchCredential: TwitchCredentials = {
         clientId,
         password

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -369,6 +369,7 @@ export function activate(context: vscode.ExtensionContext) {
         // TODO: get channels and username from extension specific settings
         const chatParams = {
           channels: configuration.get<string[]>('channels'),
+          nickname: configuration.get<string>('nickname'),
           clientId: creds.clientId,
           password: creds.password,
           announce: configuration.get<boolean>('announceBot') || false,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -363,7 +363,10 @@ export function activate(context: vscode.ExtensionContext) {
         const chatParams = {
           channels: configuration.get<string[]>('channels'),
           clientId: creds.clientId,
-          password: creds.password
+          password: creds.password,
+          announce: configuration.get<boolean>('announceBot') || false,
+          joinMessage: configuration.get<string>('joinMessage') || "",
+          leaveMessage: configuration.get<string>('leaveMessage') || ""
         };
         client.sendRequest('startchat', chatParams).then(
           result => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -155,7 +155,11 @@ connection.onShutdown(() => {
     });
 });
 
-function getTwitchChatOptions(params: any): tmi.ClientOptions {
+function getTwitchChatOptions(params: {
+  channels: string[],
+  clientId: string,
+  password: string
+}): tmi.ClientOptions {
   return {
     channels: params.channels,
     connection: {
@@ -167,7 +171,7 @@ function getTwitchChatOptions(params: any): tmi.ClientOptions {
     },
     options: {
       clientId: params.clientId,
-      debug: true
+      debug: true /* True if you want DEBUG messages in your terminal; false otherwise */
     }
   };
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -157,6 +157,7 @@ connection.onShutdown(() => {
 
 function getTwitchChatOptions(params: {
   channels: string[];
+  nickname: string;
   clientId: string;
   password: string;
 }): tmi.ClientOptions {
@@ -166,7 +167,7 @@ function getTwitchChatOptions(params: {
       reconnect: true
     },
     identity: {
-      username: 'vscodehighlighterbot',
+      username: params.nickname,
       password: params.password
     },
     options: {

--- a/src/server.ts
+++ b/src/server.ts
@@ -10,7 +10,7 @@ import {
 
 import * as tmi from 'twitch-js';
 
-let botparams: { announce: boolean, joinMessage: string, leaveMessage: string };
+let botparams: { announce: boolean; joinMessage: string; leaveMessage: string };
 let ttvChatClient: tmi.Client;
 let connection: IConnection = createConnection(
   new IPCMessageReader(process),
@@ -25,8 +25,7 @@ connection.onInitialize(
       }
     };
   }
-);
-connection.onInitialized((params: InitializedParams) => {
+);connection.onInitialized((params: InitializedParams) => {
   // connection.sendNotification('connected');
 });
 
@@ -36,7 +35,7 @@ connection.onRequest('stopchat', async () => {
   if (!ttvChatClient) {
     return false;
   }
-  if (botparams.announce && botparams.leaveMessage !== "") {
+  if (botparams.announce && botparams.leaveMessage !== '') {
     await ttvChatClient.channels.forEach((channel: string) => {
       ttvChatClient.say(channel, botparams.leaveMessage);
     });
@@ -52,28 +51,25 @@ connection.onRequest('stopchat', async () => {
     });
 });
 
-connection.onRequest(
-  'startchat',
-  (params) => {
-    botparams = { ...params };
-    ttvChatClient = new tmi.Client(getTwitchChatOptions(params));
-    return ttvChatClient
-      .connect()
-      .then(() => {
-        ttvChatClient.on('join', onTtvChatJoin);
-        ttvChatClient.on('chat', onTtvChatMessage);
-        return;
-      })
-      .catch((error: any) => {
-        console.error('There was an issue connecting to Twitch');
-        console.error(error);
-        throw error;
-      });
-  }
-);
+connection.onRequest('startchat', params => {
+  botparams = { ...params };
+  ttvChatClient = new tmi.Client(getTwitchChatOptions(params));
+  return ttvChatClient
+    .connect()
+    .then(() => {
+      ttvChatClient.on('join', onTtvChatJoin);
+      ttvChatClient.on('chat', onTtvChatMessage);
+      return;
+    })
+    .catch((error: any) => {
+      console.error('There was an issue connecting to Twitch');
+      console.error(error);
+      throw error;
+    });
+});
 
 function onTtvChatJoin(channel: string, username: string, self: boolean) {
-  if (self && botparams.announce && botparams.joinMessage !== "") {
+  if (self && botparams.announce && botparams.joinMessage !== '') {
     ttvChatClient.say(channel, botparams.joinMessage);
   }
   console.log(`[${username} has JOINED the channel ${channel}`);
@@ -160,9 +156,9 @@ connection.onShutdown(() => {
 });
 
 function getTwitchChatOptions(params: {
-  channels: string[],
-  clientId: string,
-  password: string
+  channels: string[];
+  clientId: string;
+  password: string;
 }): tmi.ClientOptions {
   return {
     channels: params.channels,
@@ -170,7 +166,7 @@ function getTwitchChatOptions(params: {
       reconnect: true
     },
     identity: {
-      username: "do_not_change_me",
+      username: 'vscodehighlighterbot',
       password: params.password
     },
     options: {


### PR DESCRIPTION
The user should now be able to set the following settings for the extension:
  1. channels (The channels the twitch-js IRC module will join)
  2. highlightColor (The background color the decoration will use)
  3. highlightBorder (The CSS style the decoration border will use)
  4. announceBot (Whether the bot should announce when joining and departing the chat room)
  5. joinMessage (The message the bot will say when joining a chat room)
  6. leaveMessage (The message the bot will say when leaving a chat room)

Additionally, when the user tries to connect for the first time, and no credentials exist, the user will be prompted to set the credentials. ~~There is a bug at the moment where the VSCode input prompts cancel if VSCode loses focus. I haven't had the time to figure that one out yet.~~

# Changed Files

## package.json
- I removed the unnecessary settings that this plugin doesn't use.
- I added `highlightColor` and `highlightBorder` settings.

## extensions.ts
- I changed the `highlightDecorationType` variable to be set both when the extension is activated and when a change to the `twitchhighlighter` settings have changed.
- I created the `setupDecoratorType` function to handle setting the `highlightDecorationType` values.
- Refactored the `startChatHandler` to allow the end user to add their twitch credentials if they aren't present when they try to connect.
- Refactored the `setTwitchClientIdHandler`, `setTwitchClientIdWithCredentialManager`, `setTwitchPasswordHandler`, and `setPasswordWithCredentialManager` functions to await the VSCode input prompts when setting the twitch credentials. (Although for some reason if VSCode loses focus the prompts will close...)

## server.ts
- I changed the twitch-js module to debug by default (the twitch-js outputs more info into our log)
- I added the ability for the twitch client to announce it's arrival to the chat room and its departure. This can be adjusted in the settings.

# Addresses

#11 
#32 