### PR TITLE
Update README to include install/usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,6 @@ Some of the code in this extension has been adapted from the [twitchlint extensi
 
 ## Extension Settings
 
-Include if your extension adds any VS Code settings through the `contributes.configuration` extension point.
-
-For example:
-
-This extension contributes the following settings:
-
 - `twitchhighlighter.channels`: The channel name(s) to connect to on Twitch.
         
         Example: `['clarkio'], Another Example: ['clarkio', 'parithon']

--- a/README.md
+++ b/README.md
@@ -17,7 +17,24 @@ Some of the code in this extension has been adapted from the [twitchlint extensi
 
 - A Twitch account ([sign up here](https://www.twitch.tv/signup))
 - Register an application [here](https://glass.twitch.tv/console/apps/create)
+- An OAuth token which you can generate [here](http://twitchapps.com/tmi/)
 - [VS Code](https://code.visualstudio.com)
+
+## Getting Started
+
+From the Command Palette:
+1. Run `Twitch Highlighter: Set Client Id`
+2. Paste the Client ID from your application
+3. Run `Twitch Highlighter: Set Password`
+4. Paste your generated OAuth token with the 'OAuth:' in front
+
+Outside of the Command Palette:
+
+5. Set `twitchhighlighter.channels` to your channel in User/Workspace Settings
+
+        "twitchhighlighter.channels": ["clarkio"]
+
+6. Hit `Disconnected` at the bottom right of VS Code to connect
 
 ## Extension Settings
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,16 @@ Outside of the Command Palette:
 
 6. Hit `Disconnected` at the bottom right of VS Code to connect
 
+## Twitch Commands
+
+To highlight a line, use:
+
+        !highlight <LineNumber> OR !line <LineNumber>
+        
+To unhighlight a line, use:
+
+        !line !<LineNumber>
+
 ## Extension Settings
 
 - `twitchhighlighter.channels`: The channel name(s) to connect to on Twitch.


### PR DESCRIPTION
Without a previous knowledge of Twitch and/or the extension, it's impossible to know how to set it up, or use it. The follow changes provides enough information to help someone get started, and removes a couple of lines that are remnants of the sample README.