### PR TITLE
Bug Fixes for #42 and #44

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -132,12 +132,10 @@ export function activate(context: vscode.ExtensionContext) {
 
   const gotoHighlightCommand = vscode.commands.registerCommand(
     'twitchhighlighter.gotoHighlight',
-    (lineNumber: number, fileName: string) => {
-      vscode.workspace.openTextDocument(fileName).then((document: vscode.TextDocument) => {
-        vscode.window.showTextDocument(document).then(editor => {
-          lineNumber = lineNumber < 3 ? 2 : lineNumber;
-          editor.revealRange(document.lineAt(lineNumber - 2).range);
-        });
+    (lineNumber: number, document: vscode.TextDocument) => {
+      vscode.window.showTextDocument(document).then(editor => {
+        lineNumber = lineNumber < 3 ? 2 : lineNumber;
+        editor.revealRange(document.lineAt(lineNumber - 2).range);
       });
     }
   );
@@ -153,7 +151,7 @@ export function activate(context: vscode.ExtensionContext) {
       highlighterNode.highlights.map(highlight =>
         highlightsToRemove.push({
           lineNumber: highlight.lineNumber,
-          fileName: highlighterNode.fileName
+          fileName: highlighterNode.document.fileName
         })
       );
       highlightsToRemove.forEach(v =>
@@ -201,7 +199,7 @@ export function activate(context: vscode.ExtensionContext) {
     context,
     'twitchhighlighter.unhighlightAll',
     unhighlightAllHandler
-  );
+  );  
   // #endregion command registrations
 
   // #region command handlers
@@ -520,6 +518,14 @@ export function activate(context: vscode.ExtensionContext) {
     null,
     context.subscriptions
   );
+
+  vscode.workspace.onDidCloseTextDocument((document: vscode.TextDocument) => {
+    if (document.isUntitled) {
+      highlighters = highlighters.filter(highlight => highlight.editor.document !== document);
+      triggerUpdateDecorations();
+      twitchhighlighterTreeView.refresh();
+    }
+  });
 
   // Creates the status bar toggle button
   twitchhighlighterStatusBar = vscode.window.createStatusBarItem(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -124,7 +124,7 @@ export function activate(context: vscode.ExtensionContext) {
 
   twitchhighlighterTreeView = new TwitchHighlighterDataProvider(() => {
     return highlighters;
-  }, vscode.workspace.rootPath);
+  });
   vscode.window.registerTreeDataProvider(
     'twitchHighlighterTreeView',
     twitchhighlighterTreeView
@@ -133,12 +133,10 @@ export function activate(context: vscode.ExtensionContext) {
   const gotoHighlightCommand = vscode.commands.registerCommand(
     'twitchhighlighter.gotoHighlight',
     (lineNumber: number, fileName: string) => {
-      vscode.workspace.findFiles(fileName).then(results => {
-        vscode.workspace.openTextDocument(results[0]).then(document => {
-          vscode.window.showTextDocument(document).then(editor => {
-            lineNumber = lineNumber < 3 ? 2 : lineNumber;
-            editor.revealRange(document.lineAt(lineNumber - 2).range);
-          });
+      vscode.workspace.openTextDocument(fileName).then((document: vscode.TextDocument) => {
+        vscode.window.showTextDocument(document).then(editor => {
+          lineNumber = lineNumber < 3 ? 2 : lineNumber;
+          editor.revealRange(document.lineAt(lineNumber - 2).range);
         });
       });
     }
@@ -155,7 +153,7 @@ export function activate(context: vscode.ExtensionContext) {
       highlighterNode.highlights.map(highlight =>
         highlightsToRemove.push({
           lineNumber: highlight.lineNumber,
-          fileName: `${vscode.workspace.rootPath}\\${highlighterNode.fileName}`
+          fileName: highlighterNode.fileName
         })
       );
       highlightsToRemove.forEach(v =>

--- a/src/twitchhighlighterTreeView.ts
+++ b/src/twitchhighlighterTreeView.ts
@@ -1,11 +1,12 @@
 import * as vscode from 'vscode';
+import * as path from 'path';
 import { Highlighter, Highlight } from './highlighter';
 
 export class TwitchHighlighterDataProvider implements vscode.TreeDataProvider<HighlighterNode> {
   private _onDidChangeTreeData: vscode.EventEmitter<HighlighterNode | undefined> = new vscode.EventEmitter<HighlighterNode | undefined>();
 	readonly onDidChangeTreeData: vscode.Event<HighlighterNode | undefined> = this._onDidChangeTreeData.event;
 
-  constructor(private getHighlighters = (): Highlighter[] => [], private readonly rootPath: string | undefined) {
+  constructor(private getHighlighters = (): Highlighter[] => []) {
   }
   refresh(): void {
     console.log('Refreshing twitch highlighter tree view.');
@@ -22,10 +23,11 @@ export class TwitchHighlighterDataProvider implements vscode.TreeDataProvider<Hi
     const currentHighlighters = this.getHighlighters().filter(highlighter => highlighter.highlights.length > 0);
     const highlighterNodes = new Array<HighlighterNode>();
     currentHighlighters.forEach((highlighter) => {
-      const fileName = highlighter.editor.document.fileName.replace(this.rootPath || '', '').substr(1);
       const highlights = highlighter.highlights;
+      const fileName = highlighter.editor.document.fileName;
+      const label = path.basename(fileName);
       console.log('fileName', fileName);
-      highlighterNodes.push(new HighlighterNode(fileName, fileName, highlights, vscode.TreeItemCollapsibleState.Collapsed));
+      highlighterNodes.push(new HighlighterNode(label, fileName, highlights, vscode.TreeItemCollapsibleState.Collapsed));
     });
     return Promise.resolve(highlighterNodes);
   }
@@ -57,7 +59,7 @@ export class HighlighterNode extends vscode.TreeItem {
         childrenNodes.push(new HighlighterNode(label, this.fileName, [highlight], undefined, {
           "command": "twitchhighlighter.gotoHighlight",
           title: "",
-          arguments: [highlight.lineNumber, this.label]
+          arguments: [highlight.lineNumber, this.fileName]
         }));
       }
     });

--- a/src/twitchhighlighterTreeView.ts
+++ b/src/twitchhighlighterTreeView.ts
@@ -24,10 +24,10 @@ export class TwitchHighlighterDataProvider implements vscode.TreeDataProvider<Hi
     const highlighterNodes = new Array<HighlighterNode>();
     currentHighlighters.forEach((highlighter) => {
       const highlights = highlighter.highlights;
-      const fileName = highlighter.editor.document.fileName;
-      const label = path.basename(fileName);
-      console.log('fileName', fileName);
-      highlighterNodes.push(new HighlighterNode(label, fileName, highlights, vscode.TreeItemCollapsibleState.Collapsed));
+      const document = highlighter.editor.document;
+      const label = path.basename(highlighter.editor.document.fileName);
+      console.log('fileName', document);
+      highlighterNodes.push(new HighlighterNode(label, document, highlights, vscode.TreeItemCollapsibleState.Collapsed));
     });
     return Promise.resolve(highlighterNodes);
   }
@@ -36,7 +36,7 @@ export class TwitchHighlighterDataProvider implements vscode.TreeDataProvider<Hi
 export class HighlighterNode extends vscode.TreeItem {
   constructor(
     public readonly label: string,
-    public readonly fileName: string,
+    public readonly document: vscode.TextDocument,
     public readonly highlights: Highlight[] = [],
     public readonly collapsibleState: vscode.TreeItemCollapsibleState = vscode.TreeItemCollapsibleState.None,
     public readonly command?: vscode.Command) {
@@ -56,10 +56,10 @@ export class HighlighterNode extends vscode.TreeItem {
       if (existingNode) {
         existingNode.highlights.push(highlight);
       } else {
-        childrenNodes.push(new HighlighterNode(label, this.fileName, [highlight], undefined, {
+        childrenNodes.push(new HighlighterNode(label, this.document, [highlight], undefined, {
           "command": "twitchhighlighter.gotoHighlight",
           title: "",
-          arguments: [highlight.lineNumber, this.fileName]
+          arguments: [highlight.lineNumber, this.document]
         }));
       }
     });


### PR DESCRIPTION
# TLDR; 

The issues occured when the user opens an individual file and not a folder (workspace). This was because we used relative paths when working with the documents instead of full paths.

## Issue #44

We designed the extension to assume a workspace is always defined. This is not the case when an individual file is opened. When an individual file is opened, the `vscode.workspace.rootPath` would be `undefined` which wouldn't provide the correct fileName used by the `removeHighlighter` to identify which highlight to remove.

## Issue #42

Additionally, because the fileName was inaccurate, the `gotoHighlightCommand` did not have a good reference to open the document. VSCode assumes the incorrect fileName should result in a request for a new document. This is why when you clicked on the highlight tree-item it would open a new document instead of switching to the existing document.

---

# Identified issue

  - The `vscode.workspace.rootPath` is undefined when a user opens an individual file and not a folder (i.e. workspace).

# Resolution

  - Instead of using relative paths we now use full paths. The Treeview Item's label will only show the file name and not the full path.

# Changed Files

## twitchHighlighterTreeview.ts
  - I changed the fileName property to use the full path of the file.
  - I changed the label property to only use the file's name not the full path.
  - I removed the rootPath parameter because it is no longer required.

## extension.ts
  - I changed the `removeHighlighterCommand` to use the fileName parameter without any minipulation for relative paths.
  - I changed the `gotoHighlightCommand` to use the full path of the fileName instead of trying to find the file using a relative path.

# Addresses

#42 
#44 
