### PR TITLE
Change `channels` setting to a string

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,9 +146,9 @@
       "title": "Twitch Highlighter",
       "properties": {
         "twitchHighlighter.channels": {
-          "type": "array",
-          "default": [],
-          "description": "The channel name(s) to connect to on Twitch. Example: ['clarkio'], Another Example: ['clarkio', 'parithon']"
+          "type": "string",
+          "default": "",
+          "description": "A comma seperated list of channel name(s) to connect to on Twitch. Example: 'clarkio', Another Example: 'clarkio, parithon'"
         },
         "twitchHighlighter.nickname": {
           "type": "string",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,6 +11,7 @@ import {
 } from './twitchHighlighterTreeView';
 import { TwitchChatClient } from './twitchChatClient';
 import { Commands } from './constants';
+import { isArray } from 'util';
 
 let highlightDecorationType: vscode.TextEditorDecorationType;
 const twitchHighlighterStatusBarIcon: string = '$(plug)'; // The octicon to use for the status bar icon (https://octicons.github.com/)
@@ -24,6 +25,8 @@ let twitchHighlighterStatusBar: vscode.StatusBarItem;
 // your extension is activated the very first time the command is executed
 export function activate(context: vscode.ExtensionContext) {
   setupDecoratorType();
+
+  updateChannelsSetting();
 
   twitchChatClient = new TwitchChatClient(
     context.asAbsolutePath(path.join('out', 'twitchLanguageServer.js')),
@@ -474,6 +477,19 @@ function registerCommand(
 ) {
   let disposable = vscode.commands.registerCommand(name, handler, thisArgs);
   context.subscriptions.push(disposable);
+}
+
+/**
+ * Used to upgrade the channels setting from an array of strings ['clarkio','parithon']
+ * to a string 'clarkio, parithon'.
+ */
+function updateChannelsSetting() {
+  const configuration = vscode.workspace.getConfiguration('twitchHighlighter');
+  const channels = configuration.get<string>('channels');
+  if (isArray(channels)) {
+    // Update the global settings
+    configuration.update('channels', channels.join(', '), true);
+  }
 }
 
 function setupDecoratorType() {

--- a/src/twitchLanguageServer.ts
+++ b/src/twitchLanguageServer.ts
@@ -155,7 +155,7 @@ function getTwitchChatOptions(params: {
   password: string;
 }): tmi.ClientOptions {
   return {
-    channels: params.channels.split(','),
+    channels: params.channels.split(',').map(s => s.trim()),
     connection: {
       secure: true,
       reconnect: true,

--- a/src/twitchLanguageServer.ts
+++ b/src/twitchLanguageServer.ts
@@ -149,13 +149,13 @@ connection.onShutdown(() => {
 });
 
 function getTwitchChatOptions(params: {
-  channels: string[];
+  channels: string;
   username: string;
   clientId: string;
   password: string;
 }): tmi.ClientOptions {
   return {
-    channels: params.channels,
+    channels: params.channels.split(','),
     connection: {
       secure: true,
       reconnect: true,


### PR DESCRIPTION
### Purpose

VSCode does not have a UI experience to change settings that are of type array; users are required to edit these setting using the text editor instead of the UI editor. Instead of using an array of type string for the `channels` setting we should use a comma separated string.

### Changed Files

- `package.json` Changed the setting from an `array` to a `string` and also changed the default value from an empty array `[]` to an empty string `""`.
- `extensionts` Added a new function `updateChannelsSetting` which checks to see if the current setting is an array and if it is change it to a comma separated string value.
- `twitchLanguageServer.ts` When getting the Twitch Chat Options, we split the comma separated string of channels into an array.

### How to test

1. Clone the repo: `git clone https://github.com/clarkio/vscode-twitch-highlighter.git`.
2. Install the node dependencies: `cd vscode-twitch-highlighter && npm install`.
3. Check your settings and note that the current `channels` setting is an array, for example: ['clarkio'].
4. Press F5 or click debug button (green triangle/play button) in VSCode.
5. Check your settings again and it should now be a string, for example: 'clarkio'.
6. Connect to the chat server.
7. Use the highlight command `!line` or `!highlight` to highlight multiple lines and to add comments.
8. Use the unhighlight command `!line !<number>` to unhighlight the lines.
9. Disconnect from the chat server.

#### Addresses

#74 
