### PR TITLE
Added a test theory for our bot command

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,6 +5,7 @@ export enum Settings {
   'username' = 'nickname',
   'highlightColor' = 'highlightColor',
   'highlightBorder' = 'highlightBorder',
+  'highlightFontColor' = 'highlightFontColor',
   'announceBot' = 'announceBot',
   'joinMessage' = 'joinMessage',
   'leaveMessage' = 'leaveMessage',
@@ -13,6 +14,7 @@ export enum Settings {
 
 export enum Commands {
   'highlight' = 'twitchHighlighter.highlight',
+  'unhighlight' = 'twitchHighlighter.unhighlight',
   'unhighlightAll' = 'twitchHighlighter.unhighlightAll',
   'unhighlightSpecific' = 'twitchHighlighter.unhighlightSpecific',
   'startChat' = 'twitchHighlighter.startChat',

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,4 @@
+export const extensionId = 'clarkio.twitch-highlighter';
 export const extSuffix = 'twitchHighlighter';
 
 export enum Settings {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -268,7 +268,7 @@ export function activate(context: vscode.ExtensionContext) {
   // #region vscode events
   vscode.workspace.onDidChangeConfiguration(
     event => {
-      if (event.affectsConfiguration('twitchHighlighter')) {
+      if (event.affectsConfiguration(extSuffix)) {
         setupDecoratorType();
       }
     },
@@ -545,19 +545,19 @@ function registerCommand(
  * to a string 'clarkio, parithon'.
  */
 function updateChannelsSetting() {
-  const configuration = vscode.workspace.getConfiguration('twitchHighlighter');
-  const channels = configuration.get<string>('channels');
+  const configuration = vscode.workspace.getConfiguration(extSuffix);
+  const channels = configuration.get<string>(Settings.channels);
   if (isArray(channels)) {
     // Update the global settings
-    configuration.update('channels', channels.join(', '), true);
+    configuration.update(Settings.channels, channels.join(', '), true);
   }
 }
 
 function setupDecoratorType() {
-  const configuration = vscode.workspace.getConfiguration('twitchHighlighter');
+  const configuration = vscode.workspace.getConfiguration(extSuffix);
   highlightDecorationType = vscode.window.createTextEditorDecorationType({
-    backgroundColor: configuration.get<string>('highlightColor') || 'green',
-    border: configuration.get<string>('highlightBorder') || '2px solid white',
-    color: configuration.get<string>('highlightFontColor') || 'white'
+    backgroundColor: configuration.get<string>(Settings.highlightColor) || 'green',
+    border: configuration.get<string>(Settings.highlightBorder) || '2px solid white',
+    color: configuration.get<string>(Settings.highlightFontColor) || 'white'
   });
 }

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -1,4 +1,4 @@
-import { extSuffix, Commands, Settings } from '../constants';
+import { extensionId, extSuffix, Commands, Settings } from '../constants';
 
 //
 // Note: This example test is leveraging the Mocha test framework.
@@ -30,16 +30,19 @@ suite("Extension Tests", function () {
 
   let extension: vscode.Extension<any>;
 
-  setup(function (done) {
-    const ext = vscode.extensions.getExtension('clarkio.twitch-highlighter');
+  setup(function () {
+    const ext = vscode.extensions.getExtension(extensionId);
     if (!ext) {
       throw new Error('Extension was not found.');
     }
     if (ext) { extension = ext; }
-    done();
   });
 
-  // Defines a Mocha unit test
+  /**
+   * Because we are waiting on a process to complete in the background
+   * we use the `done` function to inform mocha that this test run is
+   * complete.
+   */
   test("Extension loads in VSCode and is active", function (done) {
     // Hopefully a 200ms timeout will allow the extension to activate within Windows
     // otherwise we get a false result.

--- a/src/test/twitchLanguageServer.test.ts
+++ b/src/test/twitchLanguageServer.test.ts
@@ -1,0 +1,97 @@
+import * as assert from 'assert';
+import { parseMessage } from '../twitchLanguageServer';
+
+interface Theory {
+  twitchUser: string;
+  message: string;
+  startLine: number;
+  endLine: number;
+  fileName?: string;
+  comment?: string;
+}
+
+suite('twitchLanguageServer Tests', function() {
+
+  test('Ensure parseMessage returns expected results', () => {
+
+    const theories: Theory[] = [
+      {
+        twitchUser: 'clarkio',
+        message: '!line 5',
+        startLine: 5,
+        endLine: 5
+      },
+      {
+        twitchUser: 'clarkio',
+        message: '!line settings.js 5',
+        startLine: 5,
+        endLine: 5,
+        fileName: 'settings.js'
+      },
+      {
+        twitchUser: 'clarkio',
+        message: '!line settings 5',
+        startLine: 5,
+        endLine: 5,
+        fileName: 'settings'
+      },
+      {
+        twitchUser: 'clarkio',
+        message: '!line 5 settings.js',
+        startLine: 5,
+        endLine: 5,
+        fileName: 'settings.js'
+      },
+      {
+        twitchUser: 'clarkio',
+        message: '!line 5 settings',
+        startLine: 5,
+        endLine: 5,
+        comment: 'settings'
+      },
+      {
+        twitchUser: 'clarkio',
+        message: '!line 5-15',
+        startLine: 5,
+        endLine: 15
+      },
+      {
+        twitchUser: 'clarkio',
+        message: '!line 5-15 comment',
+        startLine: 5,
+        endLine: 15,
+        comment: 'comment'
+      },
+      {
+        twitchUser: 'clarkio',
+        message: '!line settings.js 5-15 comment',
+        startLine: 5,
+        endLine: 15,
+        fileName: 'settings.js',
+        comment: 'comment'
+      },
+      {
+        twitchUser: 'clarkio',
+        message: '!line 5-15 settings.js comment',
+        startLine: 5,
+        endLine: 15,
+        fileName: 'settings.js',
+        comment: 'comment'
+      }
+    ];
+
+    theories.forEach(({twitchUser, message, startLine, endLine, fileName, comment}) => {
+      const result = parseMessage(twitchUser, message);
+      assert.ok(result);
+      if (result) {
+        assert.equal(result.twitchUser, twitchUser);
+        assert.equal(result.startLine, startLine);
+        assert.equal(result.endLine, endLine);
+        assert.equal(result.fileName, fileName);
+        assert.equal(result.comment, comment);
+      }
+    });
+
+  });
+
+});

--- a/src/twitchChatClient.ts
+++ b/src/twitchChatClient.ts
@@ -6,7 +6,7 @@ import {
 } from 'vscode-languageclient';
 import { workspace, window, Disposable } from 'vscode';
 import CredentialManager from './credentialManager';
-import { extSuffix, Settings } from './constants';
+import { extSuffix, Settings, Commands } from './constants';
 
 export class TwitchChatClient {
   private readonly _languageClient: LanguageClient;
@@ -104,7 +104,7 @@ export class TwitchChatClient {
    * Stop the connection to Twitch IRC
    */
   public stop() {
-    this._languageClient.sendRequest('stopchat').then(
+    this._languageClient.sendRequest(Commands.stopChat).then(
       result => {
         if (!result) {
           window.showErrorMessage(
@@ -146,7 +146,7 @@ export class TwitchChatClient {
       joinMessage: configuration.get<string>(Settings.joinMessage) || '',
       leaveMessage: configuration.get<string>(Settings.leaveMessage) || ''
     };
-    this._languageClient.sendRequest('startchat', chatParams).then(
+    this._languageClient.sendRequest(Commands.startChat, chatParams).then(
       result => {
         window.showInformationMessage(
           'Twitch Highlighter: Chat Listener Connected.'
@@ -199,14 +199,14 @@ export class TwitchChatClient {
       window.showErrorMessage(params.message);
     });
 
-    this._languageClient.onNotification('highlight', (params: any) => {
+    this._languageClient.onNotification(Commands.highlight, (params: any) => {
       console.log('highlight requested.', params);
       if (this.onHighlight) {
         this.onHighlight(params.twitchUser, params.startLine, params.endLine, params.fileName, params.comment);
       }
     });
 
-    this._languageClient.onNotification('unhighlight', (params: any) => {
+    this._languageClient.onNotification(Commands.unhighlight, (params: any) => {
       console.log('unhighlight requested.', params);
       if (this.onUnhighlight) {
         this.onUnhighlight(params.endLine, params.fileName);
@@ -236,7 +236,7 @@ export class TwitchChatClient {
       documentSelector: ['*'],
       synchronize: {
         // Synchronize the setting section to the server
-        configurationSection: 'twitchHighlighter'
+        configurationSection: extSuffix
       }
     };
   }

--- a/src/twitchLanguageServer.ts
+++ b/src/twitchLanguageServer.ts
@@ -7,6 +7,7 @@ import {
   InitializedParams,
   TextDocumentSyncKind
 } from 'vscode-languageserver/lib/main';
+import { Commands } from './constants';
 
 import * as tmi from 'twitch-js';
 
@@ -32,7 +33,7 @@ connection.onInitialized((params: InitializedParams) => {
 
 connection.listen();
 
-connection.onRequest('stopchat', async () => {
+connection.onRequest(Commands.stopChat, async () => {
   if (!ttvChatClient) {
     return false;
   }
@@ -52,7 +53,7 @@ connection.onRequest('stopchat', async () => {
     });
 });
 
-connection.onRequest('startchat', params => {
+connection.onRequest(Commands.startChat, params => {
   botparams = { ...params };
   ttvChatClient = new tmi.Client(getTwitchChatOptions(params));
   return ttvChatClient
@@ -123,7 +124,7 @@ function parseMessage(userName: string, message: string) {
   const vEndLine = endLine < startLine ? startLine : endLine;
 
   connection.sendNotification(
-    highlight ? 'highlight' : 'unhighlight',
+    highlight ? Commands.highlight : Commands.unhighlight,
     {
       twitchUser: userName,
       startLine: vStartLine,

--- a/src/twitchLanguageServer.ts
+++ b/src/twitchLanguageServer.ts
@@ -81,7 +81,7 @@ function onTtvChatMessage(channel: string, user: any, message: string) {
   parseMessage(userName, message);
 }
 
-function parseMessage(userName: string, message: string) {
+export function parseMessage(userName: string, message: string) {
 
   /**
    * Regex pattern to verify the command is a highlight command
@@ -108,7 +108,7 @@ function parseMessage(userName: string, message: string) {
    * !highlight 5
    *
    */
-  const commandPattern = /\!(?:line|highlight) (?:((?:[\w]+)?\.[\w]{1,}) )?(\!)?(\d+)(?:-{1}(\d+))?(?: ((?:[\w]+)?\.[\w]{1,}))?(?: (.+))?/;
+  const commandPattern = /\!(?:line|highlight) (?:((?:[\w]+)?\.?[\w]*) )?(\!)?(\d+)(?:-{1}(\d+))?(?: ((?:[\w]+)?\.[\w]{1,}))?(?: (.+))?/;
 
   const cmdopts = commandPattern.exec(message);
   if (!cmdopts) { return; }
@@ -123,16 +123,20 @@ function parseMessage(userName: string, message: string) {
   const vStartLine = endLine < startLine ? endLine : startLine;
   const vEndLine = endLine < startLine ? startLine : endLine;
 
+  const result = {
+    twitchUser: userName,
+    startLine: vStartLine,
+    endLine: vEndLine,
+    fileName,
+    comment
+  };
+
   connection.sendNotification(
     highlight ? Commands.highlight : Commands.unhighlight,
-    {
-      twitchUser: userName,
-      startLine: vStartLine,
-      endLine: vEndLine,
-      fileName,
-      comment
-    }
+    result
   );
+
+  return result;
 }
 
 connection.onShutdown(() => {


### PR DESCRIPTION
### Purpose

We need some tests to ensure that the `parseMessage` function is working as we expect.

I have added a test using a 'theory' concept in order to allow us to do multiple parameterized tests against the `parseMessage` function without having to add a new test for each 'theory' we want to examine.

I have added 9 theories to the test which hopefully handles the majority of the options end-users might try while using our extension.

### Added Files

- `twitchLanguageServer.test.ts` Used for all our tests against the Twitch language server.

### Changed Files

- `constants.ts` Included additional constants to use within our project.
- `extension.ts` Cleaned up some of the code to use the constants instead of hard coded strings. 
- `extension.test.ts` Cleaned up some of the code to use the constants instead of hard coded strings.
- `twitchChatClient.ts` Cleaned up some of the code to use the constants instead of hard coded strings.
- `twitchLanguageServer.ts` Cleaned up some of the code to use the constants instead of hard coded strings. Exported the `parseMessage` function in order to make it available to our tests and also changed the function to return the results so our tests can compare against it.

