### PR TITLE
Handles relative line numbers - Addresses #80

### DIFF
--- a/src/twitchLanguageServer.ts
+++ b/src/twitchLanguageServer.ts
@@ -105,9 +105,10 @@ function parseMessage(userName: string, message: string) {
    * !line 5-7 6 should be deleted
    * !line settings.json 5-7 6 should be deleted
    * !highlight 5
-   *
+   * !line -5..10 highlights 15 lines (-5 to 10) when using relative line numbers
+   * !line -5--5 highlights 1 line (-5 to -5) when using relative line numbers
    */
-  const commandPattern = /\!(?:line|highlight) (?:((?:[\w]+)?\.[\w]{1,}) )?(\!)?(\d+)(?:-{1}(\d+))?(?: ((?:[\w]+)?\.[\w]{1,}))?(?: (.+))?/;
+  const commandPattern = /\!(?:line|highlight) (?:((?:[\w]+)?\.?[\w]*) )?(\!)?(-?\d+)(?:(?:-{1}|\.{2})(-?\d+))?(?: ((?:[\w]+)?\.[\w]{1,}))?(?: (.+))?/;
 
   const cmdopts = commandPattern.exec(message);
   if (!cmdopts) { return; }


### PR DESCRIPTION
### Purpose

Adds the ability to handle highlights when the vscode is using relative line numbers.

### Changed Files

- `extension.ts` Added a function `checkLineNumbers` which checks to see if vscode is using relative line numbers, and if it is adjust the line numbers accordingly.
- `twitchLanguageServer.ts` Edited the Regex pattern to accept the enhanced command. You can now use the following:

```
!line -5-5 Highlights 10 lines when in relative mode (5 lines above and 5 lines below the cursor)
!line -5..5 Highlights the same 10 lines as above
!line -5--10 highlights lines 5-10 above the cursor
!line -5..-10 highlights the same 5 lines as above
```

### How to test

1. Clone the repo: `git clone https://github.com/clarkio/vscode-twitch-highlighter.git`.
2. Change to branch to this PR using the [vscode GitHub pull request plugin](https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github).
3. Install the node dependencies: `cd vscode-twitch-highlighter && npm install`.
4. Press F5 or click debug button (green triangle/play button) in VSCode.
5. Change the `Line Numbers` setting for vscode to `relative`.
5. Connect to the chat server.
6. Use the highlight command `!line` or `!highlight` to highlight lines using the relative numbers (the cursor is always on line zero).
9. Use the unhighlight command `!line !<number>` to unhighlight the lines.
10. Disconnect from the chat server.
11. Reset your `Line Numbers` setting for vscode.

### Addresses

#80 