### PR TITLE
Solves Issue 78

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,10 +134,17 @@
       ]
     },
     "views": {
-      "twitchHighlighter-explorer": [
+      "explorer": [
         {
           "id": "twitchHighlighterTreeView",
           "name": "Highlights"
+        }
+      ],
+      "twitchHighlighter-explorer": [
+        {
+          "id": "twitchHighlighterTreeView",
+          "name": "Highlights",
+          "when": "config.twitchHighlighter.showHighlightsInActivityBar"
         }
       ]
     },
@@ -190,6 +197,11 @@
           "type": "boolean",
           "default": false,
           "description": "Unhighlight all lines when disconnected from the chat service."
+        },
+        "twitchHighlighter.showHighlightsInActivityBar": {
+          "type": "boolean",
+          "default": false,
+          "description": "Show the Highlights activity bar."
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -140,6 +140,12 @@
           "name": "Highlights"
         }
       ],
+      "debug": [
+        {
+          "id": "twitchHighlighterTreeView",
+          "name": "Highlights"
+        }
+      ],
       "twitchHighlighter-explorer": [
         {
           "id": "twitchHighlighterTreeView",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -9,6 +9,7 @@ export enum Settings {
   'joinMessage' = 'joinMessage',
   'leaveMessage' = 'leaveMessage',
   'unhighlightOnDisconnect' = 'unhighlightOnDisconnect',
+  'showHighlightsInActivityBar' = 'showHighlightsInActivityBar',
 }
 
 export enum Commands {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -51,7 +51,7 @@ export function activate(context: vscode.ExtensionContext) {
 
   // Creates the status bar toggle button
   twitchHighlighterStatusBar = vscode.window.createStatusBarItem(
-    vscode.StatusBarAlignment.Right
+    vscode.StatusBarAlignment.Left
   );
   twitchHighlighterStatusBar.command = Commands.toggleChat;
   twitchHighlighterStatusBar.tooltip = `Twitch Highlighter Extension`;


### PR DESCRIPTION
### Purpose

As described in issue #78 we should move the status bar button to the left. Additionally, we should move the treeview from it's own Activity Bar to the 'explorer' view.

### Changed files

- `package.json` Added a new setting to allow users to turn on the activity bar view if they want, by default it is off (false). Additionally, added the treeview to the 'explorer' view. See image below.
- `constants.ts` Added the new setting name to the Settings constant.
- `extension.ts` Moved the status bar alignment from right to left to be more consistent with other extensions.

### Addresses

#78

![image](https://user-images.githubusercontent.com/8602418/53858270-5b3ad900-3f8e-11e9-858e-a766e3b55181.png)
![image](https://user-images.githubusercontent.com/8602418/53858280-6c83e580-3f8e-11e9-97e9-9eb98feb22de.png)
