### PR TITLE
Solves issue #82 - Status bar shows inaccurate status if you cancel setting token when connecting

### DIFF
--- a/src/twitchChatClient.ts
+++ b/src/twitchChatClient.ts
@@ -76,14 +76,14 @@ export class TwitchChatClient {
         if (!this.verifyToken(token, setTokenCallback)) {
           return;
         }
+        if (token === null) {
+          return;
+        }
         window.showInformationMessage(
           'Twitch Highlighter: Starting Chat Listener...'
         );
         if (this.onConnecting) {
           this.onConnecting();
-        }
-        if (token === null) {
-          return;
         }
         this.startListening(token);
       })


### PR DESCRIPTION
### Purpose

Solves issue #82 whereby the status bar button changes to 'Connecting...' prior to ensuring a token is set. When a user cancels the connection prior to entering the token the 'Connecting...' status never changes back to 'Disconnected'.

### Changed files

- `twitchChatClient.ts` Moved the 'token' sanity check prior to updating the status and starting the connection to the twitch client.

### Addresses

#82