### PR TITLE
Honor required badges to use command - Helps with Issue #51

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "twitch-highlighter",
-  "version": "0.1.5",
+  "version": "0.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -212,7 +212,7 @@
         "twitchHighlighter.requiredBadges": {
           "type": "string",
           "default": "",
-          "description": "A comma seperated list of badges required to use the highlighter command. Leave blank for no requirement. Example: moderator, subscriber, vip"
+          "description": "A comma seperated list of badges required to use the highlighter command. Leave blank for no requirement. Example: moderator, subscriber, vip. *Requires the bot to be reconnected to take effect."
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -208,6 +208,11 @@
           "type": "boolean",
           "default": false,
           "description": "Show the Highlights icon in the activity bar to display the tree view."
+        },
+        "twitchHighlighter.requiredBadges": {
+          "type": "string",
+          "default": "",
+          "description": "A comma seperated list of badges required to use the highlighter command. Example: moderator, subscriber, vip"
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -212,7 +212,7 @@
         "twitchHighlighter.requiredBadges": {
           "type": "string",
           "default": "",
-          "description": "A comma seperated list of badges required to use the highlighter command. Leave blank for no requirement. Example: moderator, subscriber, vip. *Requires the bot to be reconnected to take effect."
+          "description": "A comma seperated list of badges required to use the highlighter command. The user must have at least one of these badges to use the command. Leave blank for no requirement. Example: moderator, subscriber, vip. *Requires the bot to be reconnected to take effect."
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -212,7 +212,7 @@
         "twitchHighlighter.requiredBadges": {
           "type": "string",
           "default": "",
-          "description": "A comma seperated list of badges required to use the highlighter command. Example: moderator, subscriber, vip"
+          "description": "A comma seperated list of badges required to use the highlighter command. Leave blank for no requirement. Example: moderator, subscriber, vip"
         }
       }
     }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -12,6 +12,7 @@ export enum Settings {
   'leaveMessage' = 'leaveMessage',
   'unhighlightOnDisconnect' = 'unhighlightOnDisconnect',
   'showHighlightsInActivityBar' = 'showHighlightsInActivityBar',
+  'requiredBadges' = 'requiredBadges'
 }
 
 export enum Commands {

--- a/src/test/twitchLanguageServer.test.ts
+++ b/src/test/twitchLanguageServer.test.ts
@@ -1,5 +1,5 @@
 import * as assert from 'assert';
-import { parseMessage } from '../twitchLanguageServer';
+import { IBadges, requiredBadges, parseMessage } from '../twitchLanguageServer';
 
 interface Theory {
   twitchUser: string;
@@ -8,6 +8,9 @@ interface Theory {
   endLine: number;
   fileName?: string;
   comment?: string;
+  requireBadges?: string[];
+  badges?: IBadges;
+  shouldFail?: boolean;
 }
 
 suite('twitchLanguageServer Tests', function() {
@@ -77,12 +80,37 @@ suite('twitchLanguageServer Tests', function() {
         endLine: 15,
         fileName: 'settings.js',
         comment: 'comment'
+      },
+      {
+        twitchUser: 'moderator',
+        message: '!line 5',
+        startLine: 5,
+        endLine: 5,
+        requireBadges: ['moderator'],
+        badges: {
+          moderator: '1'
+        }
+      },
+      {
+        twitchUser: 'nonmoderator',
+        message: '!line 5',
+        startLine: 5,
+        endLine: 5,
+        requireBadges: ['moderator'],
+        shouldFail: true
       }
+
     ];
 
-    theories.forEach(({twitchUser, message, startLine, endLine, fileName, comment}) => {
-      const result = parseMessage('#clarkio', twitchUser, message, {});
-      assert.ok(result);
+    theories.forEach(({twitchUser, message, startLine, endLine, fileName, comment, requireBadges, badges, shouldFail}) => {
+      if (requireBadges) {
+        requiredBadges.push(...requireBadges);
+      }
+      const result = parseMessage('#clarkio', twitchUser, message, badges || {});
+
+      // If the 'shouldFail' flag is true, then the result should be undefined.
+      assert.ok(shouldFail ? !result : result);
+
       if (result) {
         assert.equal(result.twitchUser, twitchUser);
         assert.equal(result.startLine, startLine);

--- a/src/test/twitchLanguageServer.test.ts
+++ b/src/test/twitchLanguageServer.test.ts
@@ -81,7 +81,7 @@ suite('twitchLanguageServer Tests', function() {
     ];
 
     theories.forEach(({twitchUser, message, startLine, endLine, fileName, comment}) => {
-      const result = parseMessage(twitchUser, message, {});
+      const result = parseMessage('#clarkio', twitchUser, message, {});
       assert.ok(result);
       if (result) {
         assert.equal(result.twitchUser, twitchUser);

--- a/src/test/twitchLanguageServer.test.ts
+++ b/src/test/twitchLanguageServer.test.ts
@@ -81,7 +81,7 @@ suite('twitchLanguageServer Tests', function() {
     ];
 
     theories.forEach(({twitchUser, message, startLine, endLine, fileName, comment}) => {
-      const result = parseMessage(twitchUser, message);
+      const result = parseMessage(twitchUser, message, {});
       assert.ok(result);
       if (result) {
         assert.equal(result.twitchUser, twitchUser);

--- a/src/twitchChatClient.ts
+++ b/src/twitchChatClient.ts
@@ -144,7 +144,8 @@ export class TwitchChatClient {
       password: token,
       announce: configuration.get<boolean>(Settings.announceBot) || false,
       joinMessage: configuration.get<string>(Settings.joinMessage) || '',
-      leaveMessage: configuration.get<string>(Settings.leaveMessage) || ''
+      leaveMessage: configuration.get<string>(Settings.leaveMessage) || '',
+      requiredBadges: configuration.get<string>(Settings.requiredBadges),
     };
     this._languageClient.sendRequest(Commands.startChat, chatParams).then(
       result => {

--- a/src/twitchLanguageServer.ts
+++ b/src/twitchLanguageServer.ts
@@ -120,7 +120,7 @@ export function parseMessage(userName: string, message: string, badges: IBadges)
    *
    */
 
-  if (requiredBadges.length > 0 && (badges.broadcaster && badges.broadcaster !== '1')) {
+  if (requiredBadges && requiredBadges.length > 0 && (badges.broadcaster && badges.broadcaster !== '1')) {
     // Check to ensure the user has a required badge
     const canContinue = requiredBadges.some(badge => badges[badge] === '1');
     // Bail if the user does not have the required badge

--- a/src/twitchLanguageServer.ts
+++ b/src/twitchLanguageServer.ts
@@ -129,7 +129,7 @@ export function parseMessage(channel: string, userName: string, message: string,
     const canContinue = requiredBadges.some(badge => badges[badge] === '1');
     // Bail if the user does not have the required badge
     if (!canContinue) {
-      console.warn(`${userName} does not have a required badge to use the highlight command.`);
+      console.warn(`${userName} does not have any of the required badges to use the highlight command.`);
       return;
     }
   }

--- a/src/twitchLanguageServer.ts
+++ b/src/twitchLanguageServer.ts
@@ -11,11 +11,11 @@ import { Commands, InternalCommands } from './constants';
 
 import * as tmi from 'tmi.js';
 
-interface IBadges extends tmi.Badges {
+export interface IBadges extends tmi.Badges {
   [key: string]: string | undefined;
 }
 
-let requiredBadges: string[];
+export let requiredBadges: string[] = [];
 let botparams: { announce: boolean; joinMessage: string; leaveMessage: string };
 let ttvChatClient: tmi.Client;
 let connection: IConnection = createConnection(

--- a/src/twitchLanguageServer.ts
+++ b/src/twitchLanguageServer.ts
@@ -89,10 +89,10 @@ function onTtvChatJoin(channel: string, username: string, self: boolean) {
 function onTtvChatMessage(channel: string, user: any, message: string) {
   const userName = user['display-name'] || user.username;
   const badges = user['badges'];
-  parseMessage(userName, message, badges);
+  parseMessage(channel, userName, message, badges);
 }
 
-export function parseMessage(userName: string, message: string, badges: IBadges) {
+export function parseMessage(channel: string, userName: string, message: string, badges: IBadges) {
 
   /**
    * Regex pattern to verify the command is a highlight command

--- a/src/twitchLanguageServer.ts
+++ b/src/twitchLanguageServer.ts
@@ -124,12 +124,12 @@ export function parseMessage(channel: string, userName: string, message: string,
    *
    */
 
-  if (requiredBadges && requiredBadges.length > 0 && (badges.broadcaster && badges.broadcaster !== '1')) {
+  if (requiredBadges && requiredBadges.length > 0 && !badges.broadcaster) {
     // Check to ensure the user has a required badge
     const canContinue = requiredBadges.some(badge => badges[badge] === '1');
     // Bail if the user does not have the required badge
     if (!canContinue) {
-      console.log(`${userName} does not have a required badge to use the highlight command.`);
+      console.warn(`${userName} does not have a required badge to use the highlight command.`);
       return;
     }
   }


### PR DESCRIPTION
### Purpose

We need a way for broadcasters to limit who can use this command. This PR allows the broadcaster to set the required badges a user must have in order to use the command. Users who do not have the badge will be ignored. The broadcaster will always be allowed to use the command.

### Changed files

- `package.json` Added a new setting to capture the required badges: `twitchHighlighter.requiredBadges`
- `constants.ts` Added the new setting to the constants.
- `twitchChatClient.ts` Forwards the requiredBadges (array) setting to the twitch server using the start params.
- `twitchLanguageServer.ts` Captures the badges when a user sends a message and verifies the user has a required badge before continuing to parse the message for our highlight command.
- `twitchLanguageServer.test.ts` Added the new parameter requirements for the `parseMessage` function and added tests to ensure the requiredBadges exists and fails (as we expect) when they don't.

### Partially Addresses

#51