### PR TITLE
Provide feedback on command usage - Issue #95

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "twitch-highlighter",
-  "version": "0.1.5",
+  "version": "0.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -208,6 +208,11 @@
           "type": "boolean",
           "default": false,
           "description": "Show the Highlights icon in the activity bar to display the tree view."
+        },
+        "twitchHighlighter.usageTip": {
+          "type": "string",
+          "default": "💡 To use the !line command, use the following format: !line <number> --or-- multiple lines: !line <start>-<end> --or-- with a comment: !line <number> <comment>",
+          "description": "A tip shared by the bot when a user chats: '!line'."
         }
       }
     }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -11,7 +11,8 @@ export enum Settings {
   'joinMessage' = 'joinMessage',
   'leaveMessage' = 'leaveMessage',
   'unhighlightOnDisconnect' = 'unhighlightOnDisconnect',
-  'showHighlightsInActivityBar' = 'showHighlightsInActivityBar'
+  'showHighlightsInActivityBar' = 'showHighlightsInActivityBar',
+  'usageTip' = 'usageTip'
 }
 
 export enum Commands {

--- a/src/test/twitchLanguageServer.test.ts
+++ b/src/test/twitchLanguageServer.test.ts
@@ -81,7 +81,7 @@ suite('twitchLanguageServer Tests', function() {
     ];
 
     theories.forEach(({twitchUser, message, startLine, endLine, fileName, comment}) => {
-      const result = parseMessage(twitchUser, message);
+      const result = parseMessage('channel', twitchUser, message);
       assert.ok(result);
       if (result) {
         assert.equal(result.twitchUser, twitchUser);

--- a/src/twitchChatClient.ts
+++ b/src/twitchChatClient.ts
@@ -155,7 +155,8 @@ export class TwitchChatClient {
       password: token,
       announce: configuration.get<boolean>(Settings.announceBot) || false,
       joinMessage: configuration.get<string>(Settings.joinMessage) || '',
-      leaveMessage: configuration.get<string>(Settings.leaveMessage) || ''
+      leaveMessage: configuration.get<string>(Settings.leaveMessage) || '',
+      usageTip: configuration.get<string>(Settings.usageTip) || '',
     };
     this._languageClient.sendRequest(Commands.startChat, chatParams).then(
       result => {

--- a/src/twitchLanguageServer.ts
+++ b/src/twitchLanguageServer.ts
@@ -11,7 +11,7 @@ import { Commands, InternalCommands } from './constants';
 
 import * as tmi from 'tmi.js';
 
-let botparams: { announce: boolean; joinMessage: string; leaveMessage: string };
+let botparams: { announce: boolean; joinMessage: string; leaveMessage: string; usageTip: string; };
 let ttvChatClient: tmi.Client;
 let connection: IConnection = createConnection(
   new IPCMessageReader(process),
@@ -79,7 +79,7 @@ function onTtvChatMessage(
   user: tmi.ChatUserstate,
   message: string
 ) {
-  const userName = user['display-name'] || user.username;
+  const userName = user['display-name'] || user.username || "unknown";
   parseMessage(channel, userName, message);
 }
 
@@ -103,7 +103,9 @@ export function parseMessage(channel:string, userName: string, message: string) 
    */
   const commandOnlyPattern = /^!(?:line|highlight)$/i;
   if (commandOnlyPattern.exec(message)) {
-    ttvChatClient.say(channel, '/me To use the !line command, use the following format: !line <number> --or-- multiple lines: !line <start>-<end> --or-- with a comment: !line <number> <comment>');
+    if (botparams.usageTip && botparams.usageTip.length > 0) {
+      ttvChatClient.say(channel, `/me ${botparams.usageTip}`);
+    }
     return;
   }
 

--- a/src/twitchLanguageServer.ts
+++ b/src/twitchLanguageServer.ts
@@ -78,10 +78,25 @@ function onTtvChatJoin(channel: string, username: string, self: boolean) {
 
 function onTtvChatMessage(channel: string, user: any, message: string) {
   const userName = user['display-name'] || user.username;
-  parseMessage(userName, message);
+  parseMessage(channel, userName, message);
 }
 
-export function parseMessage(userName: string, message: string) {
+export function parseMessage(channel:string, userName: string, message: string) {
+
+  /**
+   * Regex pattern to verify the command is a highlight command without
+   * any arguments. This will send a 'howto' message back on chat to
+   * inform the users how to use the highlight command.
+   *
+   * Matches:
+   *
+   * !line
+   */
+  const commandOnlyPattern = /^!(?:line|highlight)$/;
+  if (commandOnlyPattern.exec(message)) {
+    ttvChatClient.say(channel, '/me To use the !line command, use the following format: !line <number> --or-- multiple lines: !line <start>-<end> --or-- with a comment: !line <number> <comment>');
+    return;
+  }
 
   /**
    * Regex pattern to verify the command is a highlight command

--- a/src/twitchLanguageServer.ts
+++ b/src/twitchLanguageServer.ts
@@ -92,7 +92,7 @@ export function parseMessage(channel:string, userName: string, message: string) 
    *
    * !line
    */
-  const commandOnlyPattern = /^!(?:line|highlight)$/;
+  const commandOnlyPattern = /^!(?:line|highlight)$/i;
   if (commandOnlyPattern.exec(message)) {
     ttvChatClient.say(channel, '/me To use the !line command, use the following format: !line <number> --or-- multiple lines: !line <start>-<end> --or-- with a comment: !line <number> <comment>');
     return;
@@ -123,7 +123,7 @@ export function parseMessage(channel:string, userName: string, message: string) 
    * !highlight 5
    *
    */
-  const commandPattern = /\!(?:line|highlight) (?:((?:[\w]+)?\.?[\w]*) )?(\!)?(\d+)(?:-{1}(\d+))?(?: ((?:[\w]+)?\.[\w]{1,}))?(?: (.+))?/;
+  const commandPattern = /\!(?:line|highlight) (?:((?:[\w]+)?\.?[\w]*) )?(\!)?(\d+)(?:-{1}(\d+))?(?: ((?:[\w]+)?\.[\w]{1,}))?(?: (.+))?/i;
 
   const cmdopts = commandPattern.exec(message);
   if (!cmdopts) { return; }


### PR DESCRIPTION
### Purpose

The bot should respond with instructions on how to use the command when somebody doesn't provide the required arguments with the command. See issue #95 for more details.

### Changed Files

- `package.json` - Added the 'usageTip' setting to the contributions
- `twitchChatClient.ts` - Added the `usageTip` parameter to the chatParams object.
- `twitchLanguageServer.ts` - Added a parameter that captures the 'channel' the request comes in on so the bot knows which channel to respond to. When a user only uses the '!line' command without any arguments, and the usageTip is not empty, the bot will respond with the usageTip on how to use the command.
- `constants.ts` - brings the Settings enum inline with the changes in package.json
- `twitchLanguageServer.test.ts` - brings the method inline with the changes used in the twitchLanguageServer.

### Addresses

#95