### PR TITLE
HOTFIX: Fixed a registration error with the TreeView containers

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,14 +112,14 @@
       "view/title": [
         {
           "command": "twitchHighlighter.refreshTreeView",
-          "when": "view == twitchHighlighterTreeView",
+          "when": "view == twitchHighlighterTreeView || view == twitchHighlighterTreeView-explorer || view == twitchHighlighterTreeView-debug",
           "group": "navigation"
         }
       ],
       "view/item/context": [
         {
           "command": "twitchHighlighter.removeHighlight",
-          "when": "view == twitchHighlighterTreeView",
+          "when": "view == twitchHighlighterTreeView || view == twitchHighlighterTreeView-explorer || view == twitchHighlighterTreeView-debug",
           "group": "edit"
         }
       ]
@@ -136,13 +136,13 @@
     "views": {
       "explorer": [
         {
-          "id": "twitchHighlighterTreeView",
+          "id": "twitchHighlighterTreeView-explorer",
           "name": "Highlights"
         }
       ],
       "debug": [
         {
-          "id": "twitchHighlighterTreeView",
+          "id": "twitchHighlighterTreeView-debug",
           "name": "Highlights"
         }
       ],

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -45,8 +45,22 @@ export function activate(context: vscode.ExtensionContext) {
   twitchHighlighterTreeView = new TwitchHighlighterDataProvider(() => {
     return highlighters;
   });
+
+  // TreeView registration for the Highlighter Panel
   vscode.window.registerTreeDataProvider(
     'twitchHighlighterTreeView',
+    twitchHighlighterTreeView
+  );
+
+  // TreeView registration for the Explorer Panel
+  vscode.window.registerTreeDataProvider(
+    'twitchHighlighterTreeView-explorer',
+    twitchHighlighterTreeView
+  );
+
+  // TreeView registration for the Debug Panel
+  vscode.window.registerTreeDataProvider(
+    'twitchHighlighterTreeView-debug',
     twitchHighlighterTreeView
   );
 
@@ -111,6 +125,7 @@ export function activate(context: vscode.ExtensionContext) {
       removeHighlight(v.lineNumber, v.fileName, true)
     );
     twitchHighlighterTreeView.refresh();
+    triggerUpdateDecorations();
   }
 
   function refreshTreeViewHandler() {


### PR DESCRIPTION
# Purpose 
It was brought to my attention that the treeview containers were not working as expected by @clarkio. This is a hotfix to fix the issues.

# Cause

When we registered the treeview components with VSCode we reused the same identifier for each panel the treeview is currently in (explorer, debug, and the highlighter panel). I learned that you must have a unique ID for each panel. I made the changes necessary in the `package.json` and `extension.ts` files to register our treeview with each of the panels separately which solves the problem.